### PR TITLE
[Feature] Added a reference to a new contract in case a migration is done

### DIFF
--- a/contracts/DepositVault.sol
+++ b/contracts/DepositVault.sol
@@ -1,23 +1,24 @@
 pragma solidity ^0.4.23;
 
 import './SelfKeyToken.sol';
+import './Upgradable.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol';
 
 /**
  *  Base Contract for managing general deposits and staking functionality for SelfKey
  */
-contract DepositVault {
+contract DepositVault is Upgradable {
     using SafeMath for uint256;
     using SafeERC20 for SelfKeyToken;
 
     SelfKeyToken public token;
 
     mapping(address => mapping(address => mapping(bytes32 => uint256))) public balances;
-    //mapping(address => mapping(bytes32 => uint256)) public totalStakeByService;
 
     event KEYDeposited(uint256 amount, address from, address serviceOwner, bytes32 serviceID);
     event KEYWithdrawn(uint256 amount, address from, address serviceOwner, bytes32 serviceID);
+    event NewContract(address _newContract);
 
     constructor(address _token) public {
         require(_token != address(0), "Invalid token address");
@@ -31,6 +32,7 @@ contract DepositVault {
      *  @param serviceID - Service upon which the deposit will be made
      */
     function deposit(uint256 amount, address serviceOwner, bytes32 serviceID)
+        whenNotPaused
         public
     {
         require(amount > 0,

--- a/contracts/LockedDepositVault.sol
+++ b/contracts/LockedDepositVault.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.4.23;
 
 import './DepositVault.sol';
-import 'openzeppelin-solidity/contracts/lifecycle/Pausable.sol';
 
 /**
  *  Deposit vault with time-lock functionality. Lock-in period can be set by service owners.
  */
-contract LockedDepositVault is Pausable, DepositVault{
+contract LockedDepositVault is DepositVault{
     mapping(address => mapping(address => mapping(bytes32 => uint256))) public releaseDates;
     mapping(address => mapping(bytes32 => uint256)) public lockPeriods;
 

--- a/contracts/RefundableEscrow.sol
+++ b/contracts/RefundableEscrow.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.4.23;
 
 import './DepositVault.sol';
-import 'openzeppelin-solidity/contracts/lifecycle/Pausable.sol';
 
 /**
  *  Contract for managing deferred payment for SelfKey Marketplace
  */
-contract RefundableEscrow is Pausable, DepositVault{
+contract RefundableEscrow is DepositVault{
     event PaymentMade(uint256 amount, address sender, address serviceOwner, bytes32 serviceID);
     event PaymentReleased(uint256 amount, address sender, address serviceOwner, bytes32 serviceID);
     event PaymentRefunded(uint256 amount, address sender, address serviceOwner, bytes32 serviceID);

--- a/contracts/Upgradable.sol
+++ b/contracts/Upgradable.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.23;
+
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/lifecycle/Pausable.sol';
+
+/**
+ *  Pausable contract that allows setting a reference to a new contract for migration purposes.
+ */
+contract Upgradable is Pausable {
+    address public newContract;
+
+    event NewContract(address _newContract);
+
+    /**
+     *  Sets new contract address for migration purposes.
+     *  @param _newContract - Reference to a more recently deployed contract.
+     */
+    function setNewContract(address _newContract)
+        onlyOwner
+        public
+    {
+        newContract = _newContract;
+        emit NewContract(_newContract);
+    }
+
+    /**
+     * Pauses the contract while allowing a newContract address to be defined.
+     * @param _newContract - Reference to a more recently deployed contract.
+     */
+    function pauseAndUpgrade(address _newContract)
+        onlyOwner
+        whenNotPaused
+        public
+    {
+        newContract = _newContract;
+        emit NewContract(_newContract);
+        super.pause();
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,8 +1,7 @@
 const LockedDepositVault = artifacts.require("./LockedDepositVault.sol")
 
 module.exports = deployer => {
-  //const now = new Date().getTime() / 1000
-
   const tokenAddress = "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7" // Mainnet SelfKey Token
+  //const tokenAddress = "0xcfec6722f119240b97effd5afe04c8a97caa02ee" // Ropsten KI token
   deployer.deploy(LockedDepositVault, tokenAddress)
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,7 +1,12 @@
-const LockedDepositVault = artifacts.require("./LockedDepositVault.sol")
+//const LockedDepositVault = artifacts.require("./LockedDepositVault.sol")
+const RefundableDepositVault = artifacts.require("./RefundableDepositVault.sol")
+const RefundableEscrow = artifacts.require("./RefundableEscrow.sol")
 
 module.exports = deployer => {
-  const tokenAddress = "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7" // Mainnet SelfKey Token
-  //const tokenAddress = "0xcfec6722f119240b97effd5afe04c8a97caa02ee" // Ropsten KI token
-  deployer.deploy(LockedDepositVault, tokenAddress)
+  //const tokenAddress = "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7" // Mainnet SelfKey Token
+  const tokenAddress = "0xcfec6722f119240b97effd5afe04c8a97caa02ee" // Ropsten KI token
+
+  //deployer.deploy(LockedDepositVault, tokenAddress)
+  //deployer.deploy(RefundableDepositVault, tokenAddress)
+  deployer.deploy(RefundableEscrow, tokenAddress)
 }

--- a/test/DepositVault_test.js
+++ b/test/DepositVault_test.js
@@ -109,5 +109,19 @@ contract("DepositVault", accounts => {
       )
       assert.equal(Number(depositBalance), 0)
     })
+
+    it("can be paused and upgraded", async () => {
+      await depositVault.pauseAndUpgrade(999999)
+      const paused = await depositVault.paused.call()
+      const newContract = await depositVault.newContract.call()
+      assert.equal(paused, true)
+      assert.equal(Number(newContract), 999999)
+    })
+
+    it("owner can set a new contract address", async () => {
+      await depositVault.setNewContract(
+        "0xc59a20513e3ea4c5872700075a525734c1b4418c"
+      )
+    })
   })
 })


### PR DESCRIPTION
An Upgradable contract was implemented, from which DepositVault inherits, meaning all contracts feature pausability and keep an optional reference to a newContract. The following methods are implemented:

- **setNewContract(address newContract)**: allows the owner to set a a reference for a new contract anytime.
- **pauseAndUpgrade(address newContract)**: pause wrapper that receives an address for a new contract.